### PR TITLE
Feat : ApiResponse 클래스 생성

### DIFF
--- a/src/main/java/com/hhplus/springstudy/common/constant/SuccessCode.java
+++ b/src/main/java/com/hhplus/springstudy/common/constant/SuccessCode.java
@@ -1,0 +1,29 @@
+package com.hhplus.springstudy.common.constant;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum SuccessCode {
+    // 사용자 관련 성공 코드
+    USER_READ_SUCCESS(HttpStatus.OK, "사용자 정보 조회 성공"),
+    USER_CREATE_SUCCESS(HttpStatus.OK, "사용자 생성 성공"),
+    USER_LOGIN_SUCCESS(HttpStatus.OK,"사용자 로그인 성공"),
+
+    // 게시물 관련 성공 코드
+    BOARD_ALL_READ_SUCCESS(HttpStatus.OK, "전체 게시물 조회 성공 "),
+    BOARD_READ_SUCCESS(HttpStatus.OK, "게시물 조회 성공"),
+    BOARD_CREATE_SUCCESS(HttpStatus.CREATED, "게시물 등록 성공"),
+    BOARD_UPDATE_SUCCESS(HttpStatus.OK, "게시물 수정 성공"),
+    BOARD_DELETE_SUCCESS(HttpStatus.OK, "게시물 삭제 성공");
+
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    public int getHttpStatusCode(){
+        return httpStatus.value();
+    }
+}

--- a/src/main/java/com/hhplus/springstudy/common/response/ApiResponse.java
+++ b/src/main/java/com/hhplus/springstudy/common/response/ApiResponse.java
@@ -1,0 +1,23 @@
+package com.hhplus.springstudy.common.response;
+
+import com.hhplus.springstudy.common.constant.SuccessCode;
+import lombok.Getter;
+
+@Getter
+public class ApiResponse<T> {
+    private final boolean success;
+    private final int statusCode;
+    private final String message;
+    private final T data;
+
+    public ApiResponse(SuccessCode successCode, T data) {
+        this.success = true;
+        this.statusCode = successCode.getHttpStatusCode();
+        this.message = successCode.getMessage();
+        this.data = data;
+    }
+
+    public static <T> ApiResponse<T> of(SuccessCode successCode, T data){
+        return new ApiResponse<>(successCode, data);
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

#5

## 📝작업 내용

1. 성공 상태 코드와 메시지를 관리하는 상수 모음 SuccessCode Enum 클래스 생성
2. API 호출이 성공했을 때 사용되며, 클라이언트로 JSON 응답을 일관성 있게 제공 할 수 있도록 구성
3. 응답 데이터와 함께 상태 코드와 메시지를 포함하여 전달