### PR TITLE
Feat : AuthenticationEntryPoint 및 AccessDeniedHandler 구현

### DIFF
--- a/src/main/java/com/hhplus/springstudy/common/constant/ErrorCode.java
+++ b/src/main/java/com/hhplus/springstudy/common/constant/ErrorCode.java
@@ -18,6 +18,9 @@ public enum ErrorCode {
     // 인증 관련 에러
     USER_ID_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "권한이 없습니다."),
     USER_PASSWORD_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지 않습니다."),
+    JWT_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다."),
+    JWT_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
+    JWT_TOKEN_MISSING(HttpStatus.UNAUTHORIZED, "토큰이 요청에 없습니다."),
 
     // 게시글 관련 에러 코드
     POST_ENTITY_NOT_FOUND(HttpStatus.NOT_FOUND, "게시글이 존재하지 않습니다."),

--- a/src/main/java/com/hhplus/springstudy/common/constant/ErrorCode.java
+++ b/src/main/java/com/hhplus/springstudy/common/constant/ErrorCode.java
@@ -26,6 +26,7 @@ public enum ErrorCode {
     POST_ENTITY_NOT_FOUND(HttpStatus.NOT_FOUND, "게시글이 존재하지 않습니다."),
 
     // 권한 관련 에러 코드
+    ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
     ROLE_ENTITY_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 권한이 존재하지 않습니다.");
 
 

--- a/src/main/java/com/hhplus/springstudy/config/security/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/hhplus/springstudy/config/security/CustomAccessDeniedHandler.java
@@ -1,0 +1,34 @@
+package com.hhplus.springstudy.config.security;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerExceptionResolver;
+
+import java.io.IOException;
+
+/**
+ * Spring Security 필터 체인에서 인증이 완료되었지만 리소스 접근 권한이 없을 때 호출된다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final HandlerExceptionResolver handlerExceptionResolver;
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+
+        // 로그 기록
+        log.error("Access denied: {}", accessDeniedException.getMessage());
+
+        // HandlerExceptionResolver를 통해 GlobalExceptionHandler로 예외 위임
+        handlerExceptionResolver.resolveException(request, response, null, accessDeniedException);
+    }
+}

--- a/src/main/java/com/hhplus/springstudy/config/security/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/hhplus/springstudy/config/security/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,34 @@
+package com.hhplus.springstudy.config.security;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerExceptionResolver;
+
+import java.io.IOException;
+
+/**
+ * Spring Security 필터 체인에서 JWT 검증 실패 시 호출된다.
+ * 인증되지 않은 사용자가 리소스 요청을 하는 경우 발생
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final HandlerExceptionResolver handlerExceptionResolver;
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        // 인증 실패 로그 기록
+        log.error("Authentication failed: {}", authException.getMessage());
+
+        // HandlerExceptionResolver를 사용하여 GlobalExceptionHandler로 예외 위임
+        handlerExceptionResolver.resolveException(request, response, null, authException);
+    }
+}

--- a/src/main/java/com/hhplus/springstudy/config/security/SecurityConfig.java
+++ b/src/main/java/com/hhplus/springstudy/config/security/SecurityConfig.java
@@ -21,6 +21,9 @@ import org.springframework.security.web.SecurityFilterChain;
 public class SecurityConfig {
 
     private final JwtTokenProvider jwtTokenProvider;
+    private final CustomAuthenticationEntryPoint authenticationEntryPoint;
+    private final CustomAccessDeniedHandler accessDeniedHandler;
+    private final
 
     //Http Methpd : Get 인증예외 List
     private String[] AUTH_GET_WHITELIST = {
@@ -39,8 +42,12 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(AUTH_WHITELIST).permitAll()  // 인증이 필요없는 요청
                         .requestMatchers(HttpMethod.GET, AUTH_GET_WHITELIST).permitAll()
+                        .requestMatchers("/api/admin/**").hasRole("ADMIN")  // ROLE_ADMIN만 접근 가능하도록 설정
                         .anyRequest().authenticated()   // 나머지 요청에 대해서 인증 필요
                 )
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint(authenticationEntryPoint) // 인증 실패 처리
+                        .accessDeniedHandler(accessDeniedHandler))  // 권한 부족 처리
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));  // JWT 토큰 사용으로 세션 사용 안함
         return http.build();
     }

--- a/src/main/java/com/hhplus/springstudy/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/hhplus/springstudy/exception/GlobalExceptionHandler.java
@@ -3,10 +3,15 @@ package com.hhplus.springstudy.exception;
 import com.hhplus.springstudy.common.constant.ErrorCode;
 import com.hhplus.springstudy.common.response.ErrorResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.coyote.Response;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import javax.naming.AuthenticationException;
 
 @Slf4j
 @RestControllerAdvice
@@ -16,6 +21,20 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleBusinessException(BusinessException ex) {
         ErrorResponse errorResponse = ErrorResponse.of(ex.getErrorCode(), ex.getMessage());
         return new ResponseEntity<>(errorResponse, ex.getErrorCode().getHttpStatus());
+    }
+
+    @ExceptionHandler(AuthenticationException.class)
+    public ResponseEntity<ErrorResponse> handleAuthenticationException(AuthenticationException ex){
+        log.error("AuthenticationException: {}", ex.getMessage());
+        ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.USER_ID_UNAUTHORIZED);
+        return new ResponseEntity<>(errorResponse, HttpStatus.UNAUTHORIZED);
+    }
+
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<ErrorResponse> handleAccessDeniedException(AccessDeniedException ex){
+        log.error("AccessDeniedException: {}", ex.getMessage());
+        ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.ACCESS_DENIED);
+        return new ResponseEntity<>(errorResponse, HttpStatus.FORBIDDEN);
     }
 
     @ExceptionHandler(Exception.class)


### PR DESCRIPTION
### **## #️⃣ 연관된 이슈**
- **#43**

---

### **## 📝 작업 내용**

1. **ErrorCode 추가**

- 사용자 인증 및 인가 실패 시 반환할 HTTP 상태 코드 및 에러메시지를 관리하는 열거형 추가.

2. **CustomAuthenticationEntryPoint 구현**
- 인증 실패 시 호출되는 `AuthenticationEntryPoint` 구현
  - JWT 검증 실패 또는 토큰 누락 등 인증 문제 발생시 예외 처리
  - `HandlerExceptionResolver`를 사용하여 예외를 `GlobalExceptionHandler`로 위임
  
3. **CustomAccessDeniedHandler 구현**
- 인가 실패 시 호출되는 `AccessDeniedHandler` 구현
  - 권한 부족으로 접근이 거부된 요청 발생 시 예외 처리
  - `HandlerExceptionResolver`를 사용하여 예외를 `GlobalExceptionHandler`로 위임
4. **GlobalExceptionHandler 수정**
- `HandlerExceptionResolver`로 전달된 예외를 처리하는 로직 추가
  - JSON 응답 형식으로 에러 메시지 반환
5. **SecurityConfig 수정**
- Spring Security 설정에 커스텀 예외 처리 클래스 적용
  - 인증 실패 시 `CustomAuthenticationEntryPoint` 호출 
  - 인가 실패 시 `CustomAccessDeniedHandler` 호출 
- `ROLE_ADMIN` 권한만 접근 가능한 `/admin` 엔드포인트 설정
---

### **💡 참고 사항**
- **`HandlerExceptionResolver`를 통해 예외를 `GlobalExceptionHandler`로 위임하는 이유**
  - Spring Security의 **`FilterChainProxy`**(필터)는 HTTP 요청이 컨트롤러에 도달하기 전에 동작하여 `GlobalExceptionHandler`로 예외 처리가 불가능하다.
  - `HandlerExceptionResolver`를 사용하여 필터에서 발생한 예외도 컨트롤러의 예외 처리 방식과 동일하게 동작하도록 한다.
  - 예외 처리 로직을 일관성있게 유지하고, 공통 에러 포맷 사용이 가능하다 .
---
