### PR TITLE
Feat : JwtAuthenticationFilter 구현

### DIFF
--- a/src/main/java/com/hhplus/springstudy/config/security/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/hhplus/springstudy/config/security/CustomAccessDeniedHandler.java
@@ -5,6 +5,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.stereotype.Component;
@@ -17,10 +18,14 @@ import java.io.IOException;
  */
 @Slf4j
 @Component
-@RequiredArgsConstructor
+//@RequiredArgsConstructor
 public class CustomAccessDeniedHandler implements AccessDeniedHandler {
 
     private final HandlerExceptionResolver handlerExceptionResolver;
+
+    public CustomAccessDeniedHandler(@Qualifier("handlerExceptionResolver")HandlerExceptionResolver handlerExceptionResolver) {
+        this.handlerExceptionResolver = handlerExceptionResolver;
+    }
 
     @Override
     public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {

--- a/src/main/java/com/hhplus/springstudy/config/security/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/hhplus/springstudy/config/security/CustomAuthenticationEntryPoint.java
@@ -5,6 +5,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
@@ -18,10 +19,13 @@ import java.io.IOException;
  */
 @Slf4j
 @Component
-@RequiredArgsConstructor
 public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
 
     private final HandlerExceptionResolver handlerExceptionResolver;
+
+    public CustomAuthenticationEntryPoint(@Qualifier("handlerExceptionResolver")HandlerExceptionResolver handlerExceptionResolver) {
+        this.handlerExceptionResolver = handlerExceptionResolver;
+    }
 
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {

--- a/src/main/java/com/hhplus/springstudy/config/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/hhplus/springstudy/config/security/JwtAuthenticationFilter.java
@@ -1,20 +1,23 @@
 package com.hhplus.springstudy.config.security;
 
 import com.hhplus.springstudy.config.jwt.JwtTokenProvider;
-import io.jsonwebtoken.ExpiredJwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpHeaders;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.servlet.HandlerExceptionResolver;
 
 import java.io.IOException;
 
@@ -24,51 +27,57 @@ import java.io.IOException;
  * 해당 클래스를 상속받아서 구현하자.
  */
 @Slf4j
-@RequiredArgsConstructor
+@Component
+// wtAuthenticationFilter가 HandlerExceptionResolver를 주입받아 예외를 처리합니다.
+//Spring 컨텍스트에 HandlerExceptionResolver 타입의 빈이 2개 이상 등록되어 있어서, Spring이 어떤 빈을 주입해야 할지 모호하여 오류가 발생합니다.
+// **Lombok의 @RequiredArgsConstructor**가 생성자를 생성할 때 @Qualifier와 같은 애노테이션을 처리하지 못해서 발생
+// 따라서 생성자를 명시적으로 작성하는 방법으로 진행
+//@RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
     private final JwtTokenProvider jwtTokenProvider;
     private final CustomUserDetailsService userDetailsService;
+    private final HandlerExceptionResolver handlerExceptionResolver;
+
+    public JwtAuthenticationFilter(JwtTokenProvider jwtTokenProvider, CustomUserDetailsService userDetailsService, @Qualifier("handlerExceptionResolver")HandlerExceptionResolver handlerExceptionResolver) {
+        this.jwtTokenProvider = jwtTokenProvider;
+        this.userDetailsService = userDetailsService;
+        this.handlerExceptionResolver = handlerExceptionResolver;
+    }
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
-        try{
+        try {
             // 0. SecurityContext에 인증 정보가 이미 있다면 JWT 검증 스킵
-            if (SecurityContextHolder.getContext().getAuthentication() != null) {
-                filterChain.doFilter(request, response);
-                return;
+            if (SecurityContextHolder.getContext().getAuthentication() == null) {
+                // 1. Authorization 헤더에서 JWT 추출
+                String jwt = extractJwtFromRequest(request);
+
+                // 2. JWT 검증 및 사용자 정보 설정
+                if (StringUtils.hasText(jwt) && jwtTokenProvider.validateToken(jwt)) {
+                    // 3. 사용자 정보 추출
+                    String username = jwtTokenProvider.extractUserId(jwt);
+                    UserDetails userDetails = userDetailsService.loadUserByUsername(username);
+
+                    // 4. 인증 객체 생성 및 SecurityContext에 설정
+                    UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+                    authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+
+                    SecurityContextHolder.getContext().setAuthentication(authentication);
+                }
             }
+            // 5. 다음 필터로 요청 전달
+            filterChain.doFilter(request, response);
 
-            // 1. Authorization 헤더에서 JWT 추출
-            String jwt = extractJwtFromRequest(request);
-
-            // 2. JWT 검증 및 사용자 정보 설정
-            if (StringUtils.hasText(jwt) && jwtTokenProvider.validateToken(jwt)) {
-                String username = jwtTokenProvider.extractUserId(jwt);
-                UserDetails userDetails = userDetailsService.loadUserByUsername(username);
-
-                UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
-                authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
-
-                // SecurityContext에 인증 정보 저장
-                SecurityContextHolder.getContext().setAuthentication(authentication);
-            }
-        }catch(ExpiredJwtException e){
-            log.warn("토큰이 만료되었습니다 : {} ", e.getMessage());
-            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-            response.getWriter().write("Token expired");
-            return;
+        } catch(Exception ex){
+            // 6. 예외 발생 시 HandlerExceptionResolver로 위임
+            handlerExceptionResolver.resolveException(request, response, null, ex);
         }
-        catch (Exception e){
-            log.error("사용자 인증에 실패했습니다.", e);
-
-            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-            response.getWriter().write("Unauthorized: " + e.getMessage());
-            return;
-        }
-        // 3. 다음 필터로 요청 전달
-        filterChain.doFilter(request, response);
     }
 
+    /**
+     * Authorization 헤더에서 JWT 토큰 추출하는 메서드
+     */
     private String extractJwtFromRequest(HttpServletRequest request) {
         String bearerToken = request.getHeader(HttpHeaders.AUTHORIZATION);
         if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {

--- a/src/main/java/com/hhplus/springstudy/config/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/hhplus/springstudy/config/security/JwtAuthenticationFilter.java
@@ -1,0 +1,64 @@
+package com.hhplus.springstudy.config.security;
+
+import com.hhplus.springstudy.config.jwt.JwtTokenProvider;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+/**
+ * JWT 인증 필터는 요청 당 한 번만 실행되는 것이 적합하다.
+ * OncePerRequestFilter는 SpringSecurity에서 제공하는 요청 당 한 번만 실행되는 필터이다.
+ * 해당 클래스를 상속받아서 구현하자.
+ */
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+    private final JwtTokenProvider jwtTokenProvider;
+    private final CustomUserDetailsService userDetailsService;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+
+        // 0. SecurityContext에 인증 정보가 이미 있다면 JWT 검증 스킵
+        if (SecurityContextHolder.getContext().getAuthentication() != null) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        // 1. Authorization 헤더에서 JWT 추출
+        String jwt = extractJwtFromRequest(request);
+
+        // 2. JWT 검증 및 사용자 정보 설정
+        if (StringUtils.hasText(jwt) && jwtTokenProvider.validateToken(jwt)) {
+            String username = jwtTokenProvider.extractUserId(jwt);
+            UserDetails userDetails = userDetailsService.loadUserByUsername(username);
+
+            UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+            authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+
+            // SecurityContext에 인증 정보 저장
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        // 3. 다음 필터로 요청 전달
+        filterChain.doFilter(request, response);
+    }
+
+    private String extractJwtFromRequest(HttpServletRequest request) {
+        String bearerToken = request.getHeader(HttpHeaders.AUTHORIZATION);
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/hhplus/springstudy/config/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/hhplus/springstudy/config/security/JwtAuthenticationFilter.java
@@ -1,11 +1,13 @@
 package com.hhplus.springstudy.config.security;
 
 import com.hhplus.springstudy.config.jwt.JwtTokenProvider;
+import io.jsonwebtoken.ExpiredJwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -21,6 +23,7 @@ import java.io.IOException;
  * OncePerRequestFilter는 SpringSecurity에서 제공하는 요청 당 한 번만 실행되는 필터이다.
  * 해당 클래스를 상속받아서 구현하자.
  */
+@Slf4j
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final JwtTokenProvider jwtTokenProvider;
@@ -28,28 +31,40 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        try{
+            // 0. SecurityContext에 인증 정보가 이미 있다면 JWT 검증 스킵
+            if (SecurityContextHolder.getContext().getAuthentication() != null) {
+                filterChain.doFilter(request, response);
+                return;
+            }
 
-        // 0. SecurityContext에 인증 정보가 이미 있다면 JWT 검증 스킵
-        if (SecurityContextHolder.getContext().getAuthentication() != null) {
-            filterChain.doFilter(request, response);
+            // 1. Authorization 헤더에서 JWT 추출
+            String jwt = extractJwtFromRequest(request);
+
+            // 2. JWT 검증 및 사용자 정보 설정
+            if (StringUtils.hasText(jwt) && jwtTokenProvider.validateToken(jwt)) {
+                String username = jwtTokenProvider.extractUserId(jwt);
+                UserDetails userDetails = userDetailsService.loadUserByUsername(username);
+
+                UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+                authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+
+                // SecurityContext에 인증 정보 저장
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
+        }catch(ExpiredJwtException e){
+            log.warn("토큰이 만료되었습니다 : {} ", e.getMessage());
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            response.getWriter().write("Token expired");
             return;
         }
+        catch (Exception e){
+            log.error("사용자 인증에 실패했습니다.", e);
 
-        // 1. Authorization 헤더에서 JWT 추출
-        String jwt = extractJwtFromRequest(request);
-
-        // 2. JWT 검증 및 사용자 정보 설정
-        if (StringUtils.hasText(jwt) && jwtTokenProvider.validateToken(jwt)) {
-            String username = jwtTokenProvider.extractUserId(jwt);
-            UserDetails userDetails = userDetailsService.loadUserByUsername(username);
-
-            UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
-            authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
-
-            // SecurityContext에 인증 정보 저장
-            SecurityContextHolder.getContext().setAuthentication(authentication);
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            response.getWriter().write("Unauthorized: " + e.getMessage());
+            return;
         }
-
         // 3. 다음 필터로 요청 전달
         filterChain.doFilter(request, response);
     }
@@ -59,6 +74,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
             return bearerToken.substring(7);
         }
+        log.warn("유효하지 않은 헤더 인증 요청 : {}", bearerToken);
         return null;
     }
 }

--- a/src/main/java/com/hhplus/springstudy/config/security/SecurityConfig.java
+++ b/src/main/java/com/hhplus/springstudy/config/security/SecurityConfig.java
@@ -2,6 +2,8 @@ package com.hhplus.springstudy.config.security;
 
 import com.hhplus.springstudy.config.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -14,6 +16,8 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.servlet.HandlerExceptionResolver;
 
 @Configuration
 @EnableWebSecurity
@@ -23,7 +27,7 @@ public class SecurityConfig {
     private final JwtTokenProvider jwtTokenProvider;
     private final CustomAuthenticationEntryPoint authenticationEntryPoint;
     private final CustomAccessDeniedHandler accessDeniedHandler;
-    private final
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     //Http Methpd : Get 인증예외 List
     private String[] AUTH_GET_WHITELIST = {
@@ -48,7 +52,8 @@ public class SecurityConfig {
                 .exceptionHandling(ex -> ex
                         .authenticationEntryPoint(authenticationEntryPoint) // 인증 실패 처리
                         .accessDeniedHandler(accessDeniedHandler))  // 권한 부족 처리
-                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));  // JWT 토큰 사용으로 세션 사용 안함
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))  // JWT 토큰 사용으로 세션 사용 안함
+                .addFilterBefore(this.jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
         return http.build();
     }
 
@@ -69,5 +74,7 @@ public class SecurityConfig {
     public PasswordEncoder passwordEncoder(){
         return new BCryptPasswordEncoder();
     }
+
+
 }
 

--- a/src/main/java/com/hhplus/springstudy/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/hhplus/springstudy/exception/GlobalExceptionHandler.java
@@ -7,11 +7,11 @@ import org.apache.coyote.Response;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-import javax.naming.AuthenticationException;
 
 @Slf4j
 @RestControllerAdvice


### PR DESCRIPTION
### **## #️⃣ 연관된 이슈**
- **#42**

---

### **## 📝 작업 내용**

1. **CustomAuthenticationEntryPoint, CustomAccessDeniedHandler  수정**
  - `HandlerExceptionResolver` Bean이 두 개 등록되어 있어, Bean 호출 시 충돌이 발생
    - `@Qualifer`를 사용하여 호출할 Bean의 이름을 명시적으로 지정
    - `Lombok`의 `@RequiredArgsConstructor` 사용 시 `@Qualifer`와 충돌이 발생하므로 `@RequiredArgsConsturctor`를 제거하고 명시적으로 생성자를 작성하여 의존성 주입
2. **GlobalExceptionHandler 수정**
- `AuthenticationException` 처리 시 잘못된 클래스 `javax.naming.AuthenticationException`를 사용하여 예외 처리 불가
  - `org.springframework.security.core.AuthenticationException`을 사용하도록 수정
3. **JwtAuthenticationFilter 구현**
- 요청당 한 번만 실행되도록 `OncePerRequestFilter`를 상속받아 JWT 필터 구현 
- 요청의 `Authorization` 헤더에서 토큰 추출 
- JWT 검증 및 사용자 정보 추출 후, 인증 객체를 생성하여 SpringSecurity의 `SecurityContext`에 설정
---

### **💡 참고 사항**
**1. `@Qualifier` 사용 이유**
  - Bean의 이름이 명확히 지정되지 않을 경우 동일한 타입의 Bean이 여러 개 등록되어 있을 때 Spring이 어떤 Bean을 사용할지 알 수 없어 충돌이 발생한다
  - `@Qualifier`를 사용하여 정확한 Bean을 지정하여 충돌을 방지한다.
---
### **💡 확인 사항**
- `CustomAuthenticationEntryPoint` , `CustomAccessDeniedHandler`의 Bean 충돌 문제 에러가 발생하여 `@Qualifier`를 사용하여 해결한 상태.
- 이후 추가 테스트 진행 시 `@Qualifier`을 삭제한 이전 코드로 실행했는데 에러 없이 정상 동작 하는 것을 확인.
- 나중에 한 번 더 확인 필요