### PR TITLE
Feat : 회원가입 비밀번호 암호화

### DIFF
--- a/src/main/java/com/hhplus/springstudy/service/user/UserService.java
+++ b/src/main/java/com/hhplus/springstudy/service/user/UserService.java
@@ -11,6 +11,7 @@ import com.hhplus.springstudy.exception.BusinessException;
 import com.hhplus.springstudy.repository.role.RoleRepository;
 import com.hhplus.springstudy.repository.user.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,6 +23,7 @@ import java.util.List;
 public class UserService {
     private final UserRepository userRepository;
     private final RoleRepository roleRepository;
+    private final PasswordEncoder passwordEncoder;
 
     @Transactional(propagation = Propagation.REQUIRED)
     public UserResponseDto registerUser(UserSaveRequestDto requestDto) {
@@ -29,9 +31,11 @@ public class UserService {
         if (userRepository.findByUserId(requestDto.getUserId()).isPresent()) {
             throw new BusinessException(ErrorCode.USER_ID_DUPLICATE_INPUT);
         }
+        // 비밀번호 암호화 추가
+        String encryptPassword = passwordEncoder.encode(requestDto.getUserPassword());
 
         // 2. User 엔티티 생성
-        User user = new User(requestDto.getUserId(), requestDto.getUserPassword(), requestDto.getUserName());
+        User user = new User(requestDto.getUserId(), encryptPassword, requestDto.getUserName());
 
         // 3. 입력받은 권한이 DB에 존재하는지 확인
         List<Role> roles = resolveRoles(requestDto.getRoleIds());


### PR DESCRIPTION
### **## #️⃣ 연관된 이슈**
- **#49**

---

### **## 📝 작업 내용**

1. **UserService.registerUser() 수정**
- 회원가입 요청 데이터를 처리하는 로직에서, 클라이언트가 전달한 **비밀번호를 암호화**하여 저장하도록 수정
- `Spring Security`의 **PasswordEncoder**를 사용해 비밀번호를 안전하게 **해시 암호화** 처리
- 데이터베이스에는 암호화된 비밀번호만 저장

---

### **💡 참고 사항**
1. **`BCryptPasswordEncoder`를 활용한 암호화**
- `PasswordEncoder` Bean은 `SecurityConfig`에 등록되어 있음
- `UserService`에서 `PasswordEncoder` Bean을 주입받아 비밀번호 암호화
