### PR TITLE
Fix : JwtFilter에서 CustomPrincipal 활용으로 인증 객체 최적화

### DIFF
--- a/src/main/java/com/hhplus/springstudy/config/security/CustomPrincipal.java
+++ b/src/main/java/com/hhplus/springstudy/config/security/CustomPrincipal.java
@@ -1,0 +1,37 @@
+package com.hhplus.springstudy.config.security;
+
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.GrantedAuthority;
+
+import lombok.Getter;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+/**
+ * JWT 토큰에서 추출한 사용자 정보를 담는 클래스
+ * Spring Security의 인증 객체에서 사용됨
+ */
+@Getter
+public class CustomPrincipal {
+    private String userId;
+    private final Collection<? extends GrantedAuthority> authorities;
+
+    public CustomPrincipal(String userId, Collection<? extends GrantedAuthority> authorities) {
+        this.userId = userId;
+        this.authorities = authorities;
+    }
+
+    /**
+     * 콤마로 구분된 role 문자열을 GrantedAuthority 컬렉션으로 변환
+     * EX: "ROLE_USER, ROLE_ADMIN" -> [SimpleGrantedAuthority("ROLE_USER"), SimpleGrantedAuthority("ROLE_ADMIN ")]
+     */
+    public Collection<? extends GrantedAuthority> convertRolesToAuthorities(String roles) {
+        List<String> roleList = Arrays.asList(roles.split(","));
+        return roleList.stream()
+                .map(SimpleGrantedAuthority::new)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/hhplus/springstudy/config/security/CustomPrincipal.java
+++ b/src/main/java/com/hhplus/springstudy/config/security/CustomPrincipal.java
@@ -17,20 +17,15 @@ import java.util.stream.Collectors;
 @Getter
 public class CustomPrincipal {
     private String userId;
-    private final Collection<? extends GrantedAuthority> authorities;
+    private List<String> roles;
 
-    public CustomPrincipal(String userId, Collection<? extends GrantedAuthority> authorities) {
+    public CustomPrincipal(String userId, List<String> roles) {
         this.userId = userId;
-        this.authorities = authorities;
+        this.roles = roles;
     }
 
-    /**
-     * 콤마로 구분된 role 문자열을 GrantedAuthority 컬렉션으로 변환
-     * EX: "ROLE_USER, ROLE_ADMIN" -> [SimpleGrantedAuthority("ROLE_USER"), SimpleGrantedAuthority("ROLE_ADMIN ")]
-     */
-    public Collection<? extends GrantedAuthority> convertRolesToAuthorities(String roles) {
-        List<String> roleList = Arrays.asList(roles.split(","));
-        return roleList.stream()
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return roles.stream()
                 .map(SimpleGrantedAuthority::new)
                 .collect(Collectors.toList());
     }


### PR DESCRIPTION
### **## #️⃣ 연관된 이슈**
- **#52**

---

### **## 📝 작업 내용**

1. **CustomPrincipal** 클래스 생성
    - JWT 인증 필터에서 사용한 인증 정보를 `SecurityContext`에 저장할 때 기존 `UserDetails` 대신 사용할 `CustomPrincipal` 클래스 생성
    - 주요 필드: 
      - `userId` : 사용자 아이디
      - `roles` : 사용자 권한 목록

2.  `JwtAuthenticationFilter` 수정
    - 기존 로직 제거: 
      - `UserDetailService.loadUserByUsername()`호출 제거
      - `UserDetails` 객체 생성 삭제
    - 새로운 로직 추가:
      - JWT에서 추출한 사용자 정보(`userId`, `roles`)를 기반으로 `CustomPrincipal` 객체 생성 
      - JWT에서 추출한 권한 목록(문자열 리스트)을 `GrantedAuthority` 타입으로 변환하여 사용자 인증 객체 생성
---

### **💡 참고 사항**
1. Lazy Loading 문제 방지 
    - 기존 로직:
      - `UserDetailsService`를 통해 DB에서 사용자 정보 조회
      - 조회된 데이터로 `UserDetails` 객체를 생성하며 내부 `mapRolesToAuthorities()` 메서드에 의해서 `UserRole` 데이터를 호출
      - `UserRole` 엔티티가 `Lazy` 설정되어 영속성 컨텍스트에 포함되지 않아 `Hibernate LazyInitializationException` 발생
    - 개선된 로직:
      - `CustomPrincipal`을 사용하여 DB 조회 없이 JWT에서 가져온 `userId`와 `roles`를 활용
      - 불필요한 DB 호출을 제거하여 성능 최적화 및 Lazy Loading 문제 해결

